### PR TITLE
Plugin name and rule prefix must match

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Then configure the rules you want to use under the rules section.
 ```json
 {
     "rules": {
-        "eslint-no-global-lodash/no-global-lodash": 2
+        "no-global-lodash/no-global-lodash": 2
     }
 }
 ```


### PR DESCRIPTION
As listed, the documentation will generate errors. The specified plugin name must match the prefix. 